### PR TITLE
Ignore exceptions to continue loop.

### DIFF
--- a/lib/fluent/plugin/in_jolokia.rb
+++ b/lib/fluent/plugin/in_jolokia.rb
@@ -57,15 +57,19 @@ module Fluent
       until @finished
         sleep @run_interval
 
-        tag         = @tag
-        value       = get_attribute(@jmx_bean, @jmx_attribute, @jmx_path)
-        value[:url] = @jolokia_url if @add_jolokia_url
+        begin 
+          tag         = @tag
+          value       = get_attribute(@jmx_bean, @jmx_attribute, @jmx_path)
+          value[:url] = @jolokia_url if @add_jolokia_url
 
-        Engine.emit(
-          tag, 
-          Engine.now.to_i,
-          value
-        )
+          Engine.emit(
+            tag, 
+            Engine.now.to_i,
+            value
+          )
+        rescue => e
+          $log.warn "Failed to get JMX attribute, but ignored: #{e.message}"
+        end
         
       end
     end  


### PR DESCRIPTION
Keep getting JMX attributes if JVM processes are down for some reasons like maintenance, restart, etc.
